### PR TITLE
Minor change in description

### DIFF
--- a/event_dispatcher.rst
+++ b/event_dispatcher.rst
@@ -118,7 +118,7 @@ listener class:
 #. If the ``kernel.event_listener`` tag defines the ``method`` attribute, that's
    the name of the method to be called;
 #. If no ``method`` attribute is defined, try to call the method whose name
-   is ``on`` + "camel-cased event name" (e.g. ``onKernelException()`` method for
+   is ``on`` + "PascalCased event name" (e.g. ``onKernelException()`` method for
    the ``kernel.exception`` event);
 #. If that method is not defined either, try to call the ``__invoke()`` magic
    method (which makes event listeners invokable);


### PR DESCRIPTION
Listener's method call order 

It's visually quicker to catch/understand 

#. If no ``method`` attribute is defined, try to call the method whose name
   is ``on`` + "PascalCased event name" (e.g. ``onKernelException()`` method for
   the ``kernel.exception`` event);

(and more accurate ) than

#. If no ``method`` attribute is defined, try to call the method whose name
   is ``on`` + "camel-cased event name" (e.g. ``onKernelException()`` method for
   the ``kernel.exception`` event);

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `5.x` for features of unreleased versions).

-->
